### PR TITLE
Fixes bug in adding lcmtypes_drake.jar

### DIFF
--- a/util/checkDependency.m
+++ b/util/checkDependency.m
@@ -46,23 +46,23 @@ if ~ok
 
           conf.lcm_enabled = logical(exist('lcm.lcm.LCM','class'));
         end
-
-        if (conf.lcm_enabled)
-          javaaddpathProtectGlobals(fullfile(pods_get_base_path,'share','java','lcmtypes_drake.jar'));
-          [retval,info] = systemWCMakeEnv('util/check_multicast_is_loopback.sh');
-          if (retval)
-            info = strrep(info,'ERROR: ','');
-            info = strrep(info,'./',[getDrakePath,'/util/']);
-            warning('Drake:BroadcastingLCM','Currently all of your LCM traffic will be broadcast to the network, because:\n%s',info);
-          end
-        elseif nargout<1
-          disp(' ');
-          disp(' LCM not found.  LCM support will be disabled.');
-          disp(' To re-enable, add lcm-###.jar to your matlab classpath');
-          disp(' (e.g., by putting javaaddpath(''/usr/local/share/java/lcm-0.9.2.jar'') into your startup.m .');
-          disp(' ');
-        end
       end
+      if (conf.lcm_enabled)
+        javaaddpathProtectGlobals(fullfile(pods_get_base_path,'share','java','lcmtypes_drake.jar'));
+        [retval,info] = systemWCMakeEnv('util/check_multicast_is_loopback.sh');
+        if (retval)
+          info = strrep(info,'ERROR: ','');
+          info = strrep(info,'./',[getDrakePath,'/util/']);
+          warning('Drake:BroadcastingLCM','Currently all of your LCM traffic will be broadcast to the network, because:\n%s',info);
+        end
+      elseif nargout<1
+        disp(' ');
+        disp(' LCM not found.  LCM support will be disabled.');
+        disp(' To re-enable, add lcm-###.jar to your matlab classpath');
+        disp(' (e.g., by putting javaaddpath(''/usr/local/share/java/lcm-0.9.2.jar'') into your startup.m .');
+        disp(' ');
+      end
+    
     case 'lcmgl'
       checkDependency('lcm');
       conf.lcmgl_enabled = logical(exist('bot_lcmgl.data_t','class'));


### PR DESCRIPTION
This should fix the problem of not loading lcmtypes_drake.jar

This was the manual solution:
javaaddpath('path_to_drc/drc/software/build/share/java/lcmtypes_drake.jar')
