### PR TITLE
more flexible support logic for locomotion plans

### DIFF
--- a/systems/robotInterfaces/QPControllerPlan.m
+++ b/systems/robotInterfaces/QPControllerPlan.m
@@ -4,15 +4,18 @@ classdef QPControllerPlan < handle
     % to specify the support state used by the controller, based
     % on the controller's instantaneous force and kinematic input. 
     % See QPInputConstantHeight.m for a more complete description. 
+    duration = inf;
+    start_time = 0;
+    default_qp_input = atlasControllers.QPInputConstantHeight;
+    gain_set = 'standing';
+  end
+
+  properties(Constant)
     support_logic_maps = struct('require_support', ones(4,1),...
                                 'only_if_force_sensed', [0;0;1;1],...
                                 'only_if_kinematic', [0;1;0;1],...
                                 'kinematic_or_sensed', [0;1;1;1],...
                                 'prevent_support', zeros(4,1));
-    duration = inf;
-    start_time = 0;
-    default_qp_input = atlasControllers.QPInputConstantHeight;
-    gain_set = 'standing';
   end
 
   methods(Abstract)

--- a/systems/robotInterfaces/QPLocomotionPlan.m
+++ b/systems/robotInterfaces/QPLocomotionPlan.m
@@ -16,6 +16,8 @@ classdef QPLocomotionPlan < QPControllerPlan
     g = 9.81; % gravity m/s^2
     is_quasistatic = false;
 
+    planned_support_command = QPControllerPlan.support_logic_maps.require_support; % when the plan says a given body is in support, require the controller to use that support. To allow the controller to use that support only if it thinks the body is in contact with the terrain, try QPControllerPlan.support_logic_maps.kinematic_or_sensed; 
+
     last_qp_input;
   end
 
@@ -184,7 +186,7 @@ classdef QPLocomotionPlan < QPControllerPlan
       for j = 1:length(supp.bodies)
         qp_input.support_data(j).body_id = supp.bodies(j);
         qp_input.support_data(j).contact_pts = supp.contact_pts{j};
-        qp_input.support_data(j).support_logic_map = obj.support_logic_maps.require_support;
+        qp_input.support_data(j).support_logic_map = obj.planned_support_command;
         qp_input.support_data(j).mu = obj.mu;
         qp_input.support_data(j).contact_surfaces = 0;
       end


### PR DESCRIPTION
this was necessary to create the standing plan for the simulator's
internal controller, which needs to wait until its feet are on the
ground to turn on the foot contact supports