### PR TITLE
Use closestExpmap in quat2ExpmapSequence

### DIFF
--- a/util/drakeGeometryUtil.cpp
+++ b/util/drakeGeometryUtil.cpp
@@ -1353,9 +1353,9 @@ void quat2expmapSequence(const Ref<const Matrix<double,4,Dynamic>> &quat, const 
     expmap_dot.col(i) = expmap_grad.gradient().value()*quat_dot.col(i);
     if(i>=1)
     {
-      auto unwrap_grad = unwrapExpmap(expmap.col(i-1),expmap.col(i),1);
-      expmap.col(i) = unwrap_grad.value();
-      expmap_dot.col(i) = unwrap_grad.gradient().value()*expmap_dot.col(i);
+      auto closest_grad = closestExpmap(expmap.col(i-1),expmap.col(i),1);
+      expmap.col(i) = closest_grad.value();
+      expmap_dot.col(i) = closest_grad.gradient().value()*expmap_dot.col(i);
     }
   }
 }


### PR DESCRIPTION
Forgot to replace `unwrapExpmap` in C++ `quat2ExpmapSequence` with `closestExpmap`. Now change the C++ code to keep it the same as the MATLAB code. This C++ code is not used anywhere, but it is good to keep it the same as the MATLAB code